### PR TITLE
Updated to reflect deprecations in Atom 1.13.0

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -51,12 +51,12 @@ atom-text-editor {
     }
 }
 
-atom-text-editor .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region {
     background-color: transparent;
     border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region {
     border: 1px solid @syntax-result-marker-color-selected;
 }
 
@@ -67,47 +67,47 @@ atom-text-editor .search-results .marker.current-result .region {
 .syntax--keyword {
     color: @orange;
 
-    &.control {
+    &.syntax--control {
         color: lighten(@red, 19%);
 
-        &.import {
+        &.syntax--import {
             color: @blue;
         }
 
-        &.directive.conditional.c {
+        &.syntax--directive.syntax--conditional.syntax--c {
             color: @green;
         }
     }
 
-    &.operator {
+    &.syntax--operator {
         color: @syntax-text-color;
 
-        &.logical {
+        &.syntax--logical {
             color: lighten(@red, 19%);
         }
 
-        &.instanceof {
+        &.syntax--instanceof {
             color: @light-orange;
         }
     }
 
-    &.other.special-method {
+    &.syntax--other.syntax--special-method {
         color: @blue;
     }
 
-    &.other {
+    &.syntax--other {
         color: @light-orange;
 
-        &.java {
+        &.syntax--java {
             color: @aqua;
         }
 
-        &.import {
+        &.syntax--import {
             color: @aqua;
         }
     }
 
-    &.other.unit {
+    &.syntax--other.syntax--unit {
         color: @light-orange;
     }
 }
@@ -115,29 +115,29 @@ atom-text-editor .search-results .marker.current-result .region {
 .syntax--storage {
     color: lighten(@red, 19%);
 
-    &.modifier.java{
+    &.syntax--modifier.syntax--java{
         color: @light-orange;
-        &.package {
+        &.syntax--package {
             color: @syntax-text-color;
         }
     }
 
-    &.type {
+    &.syntax--type {
         color: @syntax-text-color;
-        &.primitive.java {
+        &.syntax--primitive.syntax--java {
             color: @yellow;
         }
-        &.function.python {
+        &.syntax--function.syntax--python {
             color: lighten(@red, 19%);
         }
-        &.annotation {
+        &.syntax--annotation {
             color: @blue;
         }
-        &.c {
+        &.syntax--c {
             color: @yellow;
         }
 
-        &.class.python {
+        &.syntax--class.syntax--python {
             color: lighten(@red, 19%);
         }
     }
@@ -146,23 +146,23 @@ atom-text-editor .search-results .marker.current-result .region {
 .syntax--constant {
     color: @purple;
 
-    &.character.escape {
+    &.syntax--character.syntax--escape {
         color: @light-orange;
     }
 
-    &.numeric {
+    &.syntax--numeric {
         color: darken(@purple, 5%);
     }
 
-    &.other.color {
+    &.syntax--other.syntax--color {
         color: @cyan;
     }
 
-    &.other.symbol {
+    &.syntax--other.syntax--symbol {
         color: @green;
     }
 
-    &.language.python {
+    &.syntax--language.syntax--python {
         color: @light-orange;
     }
 }
@@ -170,32 +170,32 @@ atom-text-editor .search-results .marker.current-result .region {
 .syntax--variable {
     color: @blue;
 
-    &.java {
+    &.syntax--java {
         color: @syntax-text-color;
     }
 
-    &.interpolation {
+    &.syntax--interpolation {
         color: darken(@red, 10%);
     }
 
-    &.parameter.function {
+    &.syntax--parameter.syntax--function {
         color: @syntax-text-color;
     }
 
-    &.other.normal.shell {
+    &.syntax--other.syntax--normal.syntax--shell {
         color: @aqua;
     }
 
-    &.other.loop.shell {
+    &.syntax--other.syntax--loop.syntax--shell {
         color: @syntax-text-color;
     }
 
-    &.language.self.python {
+    &.syntax--language.syntax--self.syntax--python {
         color: @yellow;
     }
 }
 
-.syntax--invalid.illegal {
+.syntax--invalid.syntax--illegal {
     background-color: @light-red;
     color: @syntax-background-color;
 }
@@ -204,158 +204,158 @@ atom-text-editor .search-results .marker.current-result .region {
     color: @green;
 
 
-    &.regexp {
+    &.syntax--regexp {
         color: @cyan;
 
-        .syntax--source.ruby.embedded {
+        .syntax--source.syntax--ruby.syntax--embedded {
             color: @orange;
         }
     }
 
-    &.other.link {
+    &.syntax--other.syntax--link {
         color: @red;
     }
 }
 
 .syntax--punctuation {
-    &.definition {
+    &.syntax--definition {
         &.syntax--comment {
             color: gray;
         }
 
-        &.syntax--string.shell {
+        &.syntax--string.syntax--shell {
             color: @syntax-text-color;
         }
 
-        &.inheritance.python {
+        &.syntax--inheritance.syntax--python {
             color: @syntax-text-color;
         }
 
         //&.syntax--string,
         &.syntax--variable,
-        &.parameters,
-        &.array {
+        &.syntax--parameters,
+        &.syntax--array {
             color: @syntax-text-color;
 
-            &.shell {
+            &.syntax--shell {
                 color: @aqua;
             }
         }
 
-        &.heading,
-        &.identity {
+        &.syntax--heading,
+        &.syntax--identity {
             color: @blue;
         }
 
-        &.bold {
+        &.syntax--bold {
             color: @light-orange;
             font-weight: bold;
         }
 
-        &.italic {
+        &.syntax--italic {
             color: @purple;
             font-style: italic;
         }
     }
 
-    &.section.embedded {
+    &.syntax--section.syntax--embedded {
         color: darken(@red, 10%);
     }
 
 }
 
 .syntax--support {
-    &.class {
+    &.syntax--class {
         color: @light-orange;
     }
 
-    &.function  {
+    &.syntax--function  {
         color: @light-orange;
 
-        &.any-method {
+        &.syntax--any-method {
             color: @blue;
         }
-        &.magic.python {
+        &.syntax--magic.syntax--python {
             color: @aqua;
         }
     }
-    &.type.exception {
+    &.syntax--type.syntax--exception {
         color: @purple;
     }
 }
 
 .syntax--entity {
-    &.name.function {
+    &.syntax--name.syntax--function {
         color: @aqua;
     }
-    &.name.type {
+    &.syntax--name.syntax--type {
         color: @light-orange;
         text-decoration: underline;
 
-        &.class.python {
+        &.syntax--class.syntax--python {
             color: @aqua;
         }
     }
 
-    &.name.type.class.java {
+    &.syntax--name.syntax--type.syntax--class.syntax--java {
         color: @syntax-text-color;
     }
 
-    &.other.inherited-class {
+    &.syntax--other.syntax--inherited-class {
         color: @green;
     }
-    &.name.class, &.name.type.class {
+    &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
         color: @light-orange;
     }
 
-    &.name.section {
+    &.syntax--name.syntax--section {
         color: @blue;
     }
 
-    &.name.tag {
+    &.syntax--name.syntax--tag {
         color: @aqua;
         text-decoration: underline;
-        &.scss {
+        &.syntax--scss {
             color: lighten(@red, 19%);
         }
     }
 
-    &.other.attribute-name {
+    &.syntax--other.syntax--attribute-name {
         color: @yellow;
 
-        &.id {
+        &.syntax--id {
             color: @blue;
         }
     }
 }
 
 .syntax--meta {
-    &.class {
+    &.syntax--class {
         color: @light-orange;
     }
 
-    &.link {
+    &.syntax--link {
         color: @orange;
     }
 
-    &.require {
+    &.syntax--require {
         color: @blue;
     }
 
-    &.selector {
+    &.syntax--selector {
         color: @purple;
     }
 
-    &.method {
+    &.syntax--method {
         color: @syntax-text-color;
     }
 
-    &.separator {
+    &.syntax--separator {
         background-color: @gray;
         color: @syntax-text-color;
     }
 
-    &.scope.case-clause-body.shell {
+    &.syntax--scope.syntax--case-clause-body.syntax--shell {
         color: @blue;
     }
 }
@@ -365,48 +365,48 @@ atom-text-editor .search-results .marker.current-result .region {
 }
 
 .syntax--markup {
-    &.bold {
+    &.syntax--bold {
         color: @orange;
         font-weight: bold;
     }
 
-    &.changed {
+    &.syntax--changed {
         color: @purple;
     }
 
-    &.deleted {
+    &.syntax--deleted {
         color: @red;
     }
 
-    &.italic {
+    &.syntax--italic {
         color: @purple;
         font-style: italic;
     }
 
-    &.heading .syntax--punctuation.definition.heading {
+    &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
         color: @blue;
     }
 
-    &.inserted {
+    &.syntax--nserted {
         color: @green;
     }
 
-    &.list {
+    &.syntax--list {
         color: @red;
     }
 
-    &.quote {
+    &.syntax--quote {
         color: @orange;
     }
 
-    &.raw.inline {
+    &.syntax--raw.syntax--inline {
         color: @green;
     }
 }
 
-.syntax--source.gfm .syntax--markup {
+.syntax--source.syntax--gfm .syntax--markup {
     -webkit-font-smoothing: auto;
-    &.heading {
+    &.syntax--heading {
         color: @green;
     }
 }

--- a/styles/base.less
+++ b/styles/base.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor, :host {
+atom-text-editor {
     background-color: @syntax-background-color;
     color: @syntax-text-color;
 
@@ -51,22 +51,20 @@ atom-text-editor, :host {
     }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .marker .region {
     background-color: transparent;
     border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .marker.current-result .region {
     border: 1px solid @syntax-result-marker-color-selected;
 }
 
-.comment {
+.syntax--comment {
     color: gray;
 }
 
-.keyword {
+.syntax--keyword {
     color: @orange;
 
     &.control {
@@ -114,7 +112,7 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.storage {
+.syntax--storage {
     color: lighten(@red, 19%);
 
     &.modifier.java{
@@ -145,7 +143,7 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.constant {
+.syntax--constant {
     color: @purple;
 
     &.character.escape {
@@ -169,7 +167,7 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.variable {
+.syntax--variable {
     color: @blue;
 
     &.java {
@@ -197,19 +195,19 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.invalid.illegal {
+.syntax--invalid.illegal {
     background-color: @light-red;
     color: @syntax-background-color;
 }
 
-.string {
+.syntax--string {
     color: @green;
 
 
     &.regexp {
         color: @cyan;
 
-        .source.ruby.embedded {
+        .syntax--source.ruby.embedded {
             color: @orange;
         }
     }
@@ -219,13 +217,13 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.punctuation {
+.syntax--punctuation {
     &.definition {
-        &.comment {
+        &.syntax--comment {
             color: gray;
         }
 
-        &.string.shell {
+        &.syntax--string.shell {
             color: @syntax-text-color;
         }
 
@@ -233,8 +231,8 @@ atom-text-editor .search-results .marker.current-result .region,
             color: @syntax-text-color;
         }
 
-        //&.string,
-        &.variable,
+        //&.syntax--string,
+        &.syntax--variable,
         &.parameters,
         &.array {
             color: @syntax-text-color;
@@ -266,7 +264,7 @@ atom-text-editor .search-results .marker.current-result .region,
 
 }
 
-.support {
+.syntax--support {
     &.class {
         color: @light-orange;
     }
@@ -286,7 +284,7 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.entity {
+.syntax--entity {
     &.name.function {
         color: @aqua;
     }
@@ -331,7 +329,7 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.meta {
+.syntax--meta {
     &.class {
         color: @light-orange;
     }
@@ -362,11 +360,11 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.none {
+.syntax--none {
     color: @syntax-text-color;
 }
 
-.markup {
+.syntax--markup {
     &.bold {
         color: @orange;
         font-weight: bold;
@@ -385,7 +383,7 @@ atom-text-editor .search-results .marker.current-result .region,
         font-style: italic;
     }
 
-    &.heading .punctuation.definition.heading {
+    &.heading .syntax--punctuation.definition.heading {
         color: @blue;
     }
 
@@ -406,14 +404,13 @@ atom-text-editor .search-results .marker.current-result .region,
     }
 }
 
-.source.gfm .markup {
+.syntax--source.gfm .syntax--markup {
     -webkit-font-smoothing: auto;
     &.heading {
         color: @green;
     }
 }
 
-atom-text-editor[mini] .scroll-view,
-:host([mini]) .scroll-view {
+atom-text-editor[mini] .scroll-view {
     padding-left: 1px;
 }


### PR DESCRIPTION
Adjusted the selectors in base.less to take into account the changes which were introduced with the 1.13 update to Atom. These changes to the theme remove the deprecation warnings and brings things up to date.